### PR TITLE
Fix redeclared enum name

### DIFF
--- a/equipment_handler/include/pcal9538a.h
+++ b/equipment_handler/include/pcal9538a.h
@@ -17,23 +17,28 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+#ifndef PCAL9538A_H_
+#define PCAL9538A_H_
+
 #include <stdint.h>
 
-#define PCAL9538A_ADDR              (0x70)
+#define PCAL9538A_ADDR (0x70)
 #ifdef IS_ATHENA
-#define PCAL9538A_PORT              i2cREG2
+#define PCAL9538A_PORT i2cREG2
 #else
-#define PCAL9538A_PORT              i2cREG1 // port used on dev board
+#define PCAL9538A_PORT i2cREG1 // port used on dev board
 #endif
 
 typedef enum {
-ADCS = 0,
-DFGM = 1,
-IRIS = 2,
-OBC = 3,
-CHARON = 4,
-UHF = 5,
+    PWR_ADCS = 0,
+    PWR_DFGM = 1,
+    PWR_IRIS = 2,
+    PWR_OBC = 3,
+    PWR_CHARON = 4,
+    PWR_UHF = 5,
 } Power_Channel;
 
 uint8_t setuppcal9538a(void);
 uint8_t triggerPowerChannelReset(Power_Channel channel);
+
+#endif

--- a/equipment_handler/test/charon_binary_test.c
+++ b/equipment_handler/test/charon_binary_test.c
@@ -3,33 +3,32 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-bool charon_binary_test(void){
+bool charon_binary_test(void) {
 
-    if(ads7128Init()){
+    if (ads7128Init()) {
         return 1;
     }
 
-    Power_Channel channel_to_reset = UHF;
-    if(setuppcal9538a()){
+    Power_Channel channel_to_reset = PWR_UHF;
+    if (setuppcal9538a()) {
         return 1;
     }
     printf("Resetting power channel %d for 2.2 s \n", channel_to_reset);
-    if(triggerPowerChannelReset(channel_to_reset)){
+    if (triggerPowerChannelReset(channel_to_reset)) {
         return 1;
     }
 
-
-
-    for(int i = 0; i<6; i++){
-        if(setuppcal9538a()){
+    for (int i = 0; i < 6; i++) {
+        if (setuppcal9538a()) {
             return 1;
         }
         printf("Resetting power channel %d for 2.2 s \n", channel_to_reset);
-        if(triggerPowerChannelReset(channel_to_reset)){
+        if (triggerPowerChannelReset(channel_to_reset)) {
             return 1;
         }
         printf("Delaying for ~10 seconds... \n");
-        for(int j = 0; j<350000000; j++);//not using freeRTOS delay for basic testing
+        for (int j = 0; j < 350000000; j++)
+            ; // not using freeRTOS delay for basic testing
         channel_to_reset = (Power_Channel)i;
     }
 
@@ -38,23 +37,22 @@ bool charon_binary_test(void){
     uint8_t max_measured_temp = 0;
     printf("Raise temperature of one sensor over 40 deg C to exit loop.\n");
     printf("Thermistor temperatures: \n");
-    while(max_measured_temp < threshold){
-        if(readAllTemps(temperatures)){
+    while (max_measured_temp < threshold) {
+        if (readAllTemps(temperatures)) {
             return 1;
         }
-        for(int i = 0; i<8; i++){
+        for (int i = 0; i < 8; i++) {
 
             printf("Channel %d = %d deg C \n", i, temperatures[i]);
-            if(temperatures[i] > max_measured_temp){
+            if (temperatures[i] > max_measured_temp) {
                 max_measured_temp = temperatures[i];
             }
             temperatures[i] = 0;
         }
         printf("\n");
-        for(int j = 0; j<1000000; j++);//not using freeRTOS delay for basic testing
+        for (int j = 0; j < 1000000; j++)
+            ; // not using freeRTOS delay for basic testing
     }
-
-
 
     return 0;
 }


### PR DESCRIPTION
The ADCS and OBC power channel enum names were conflicting with something else in the system. I couldn't find what so I just renamed the enum to be more applicable to power channels